### PR TITLE
Fix row size calculation

### DIFF
--- a/lv_bmp.c
+++ b/lv_bmp.c
@@ -152,7 +152,7 @@ static lv_res_t decoder_open(lv_img_decoder_t * decoder, lv_img_decoder_dsc_t * 
         memcpy(&b.px_width, header + 18, 4);
         memcpy(&b.px_height, header + 22, 4);
         memcpy(&b.bpp, header + 28, 2);
-        b.row_size_bytes = (b.bpp * b.px_width) / 8;
+        b.row_size_bytes = ((b.bpp * b.px_width + 31) / 32) * 4;
 
         dsc->user_data = lv_mem_alloc(sizeof(bmp_dsc_t));
         LV_ASSERT_MALLOC(dsc->user_data);


### PR DESCRIPTION
Previous code did not account for padding, rounding up to the next multiple of 4 bytes ([Reference](https://en.wikipedia.org/wiki/BMP_file_format#Pixel_storage))